### PR TITLE
chore: fix typo in patch file

### DIFF
--- a/redhat/patches/0001-dockerfile.patch
+++ b/redhat/patches/0001-dockerfile.patch
@@ -16,7 +16,7 @@ index 2e3a82f..5e63c3c 100644
 
  # Multi-Stage production build
 -FROM golang:1.20.6@sha256:cfc9d1b07b1ef4f7a4571f0b60a99646a92ef76adb7d9943f4cb7b606c6554e2 as deploy
-+FROM golang:1.20.6@shregistry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 as deploy
++FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 as deploy
 
  # Retrieve the binary from the previous stage
  COPY --from=builder /opt/app-root/src/server /usr/local/bin/fulcio-server


### PR DESCRIPTION
Copy and paste error when generating the patch file.