### PR TITLE
Add cron job for patch file

### DIFF
--- a/.github/workflows/cronjobs.yaml
+++ b/.github/workflows/cronjobs.yaml
@@ -1,0 +1,77 @@
+name: GH Actions Cron Schedule
+on:
+  workflow_dispatch:
+  schedule:
+    # Every M-F at 12:00am run this job
+    - cron:  "0 0 * * 1-5"
+env:
+  CURRENT_REDHAT_IMAGE: registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6
+
+jobs:
+  check-upstream-shas:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the upstream fulcio repository
+        uses: actions/checkout@v2
+        with:
+          repository: sigstore/fulcio
+          path: upstream-fulcio
+          ref: main
+
+      - name: Get upstream shas
+        run: |
+          cd upstream-fulcio
+          upstreamSHA=$(grep -o -m 1 'golang:[^@]\+@sha256:[a-f0-9]\{64\}' Dockerfile)
+          echo 'UPSTREAM_SHA='$upstreamSHA >> $GITHUB_ENV
+
+      - name: Pull down the midstream fulcio repository
+        uses: actions/checkout@v2
+        with:
+          path: midstream-fulcio
+          ref: main
+
+      - name: Get midstream shas
+        run: |
+          cd midstream-fulcio
+          midstreamSHA=$(grep -o -m 1 'golang:[^@]\+@sha256:[a-f0-9]\{64\}' redhat/patches/0001-dockerfile.patch)
+          echo 'MIDSTREAM_SHA='$midstreamSHA >> $GITHUB_ENV
+
+      - name: Generate new patch file
+        if: ${{ env.UPSTREAM_SHA != env.MIDSTREAM_SHA }}
+        run: |
+          cd upstream-fulcio
+          sed -i 's|${{ env.UPSTREAM_SHA }}|${{ env.CURRENT_REDHAT_IMAGE }}|g' Dockerfile
+          git diff > 0001-dockerfile.patch
+
+          cd ../midstream-fulcio
+          git fetch origin
+          git checkout -B update-dockerfile.patch-file origin/main
+
+          cp -f ../upstream-fulcio/0001-dockerfile.patch redhat/patches/
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check for existing pull request
+        if: ${{ env.UPSTREAM_SHA != env.MIDSTREAM_SHA }}
+        run: |
+          cd midstream-fulcio
+          openPRs="$(gh pr list --state open -H update-dockerfile.patch-file --json number | jq -r '.[].number' | wc -l)"
+          echo 'NUM_OPEN_PRS='$openPRs >> $GITHUB_ENV
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git config --global user.name "${GITHUB_ACTOR}"
+
+      - name: Create pull request
+        if: ${{ env.NUM_OPEN_PRS == 0 && env.UPSTREAM_SHA != env.MIDSTREAM_SHA }}
+        run: |
+          cd midstream-fulcio
+          git add .
+          git commit -m "Update image in docker file"
+          git push -f origin update-dockerfile.patch-file
+          gh pr create --base main --head update-dockerfile.patch-file --title "Update patch file" --body "This is an automated pr to update the docker patch file"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pr is related to this slack [message](https://redhat-internal.slack.com/archives/C05M2GGKU7Q/p1693321174551639?thread_ts=1693320909.554809&cid=C05M2GGKU7Q), and involves adding a GitHub action that periodically compares the Images located in the upstream docker files to the ones in our patch files, if they are different the action will generate a patch file to replace our current one, then creates a pr.

## Testing

1. Fork the repo
2. Change settings mentioned in the comments section
3. Modify the sha for the golang image in the redhat/patches/0001-dockerfile.patch file (the sha should still be a valid sha just different from the original)
4. Run the action and it should create an automated pr with the new patch file

## Comments
In order for the action to work correctly there are two settings that need to be changed for the repo.

1. Actions need to be able to create pull requests (settings -> Actions -> General -> Workflow permissions)
2. Actions need read and write permissions (settings -> Actions -> General -> Workflow permissions)