### PR TITLE
Overrides base image labels for enterprise-contract

### DIFF
--- a/redhat/patches/0001-dockerfile.patch
+++ b/redhat/patches/0001-dockerfile.patch
@@ -1,12 +1,12 @@
 diff --git a/Dockerfile b/Dockerfile
-index 5b6f43b..954235d 100644
+index 9bbd3a2..1eba662 100644
 --- a/Dockerfile
 +++ b/Dockerfile
 @@ -13,7 +13,7 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
 
--FROM golang:1.20.7@sha256:bc5f0b5e43282627279fe5262ae275fecb3d2eae3b33977a7fd200c7a760d6f1 AS builder
+-FROM golang:1.21.1@sha256:c416ceeec1cdf037b80baef1ccb402c230ab83a9134b34c0902c542eb4539c82 AS builder
 +FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 AS builder
  ENV APP_ROOT=/opt/app-root
  ENV GOPATH=$APP_ROOT
@@ -15,8 +15,18 @@ index 5b6f43b..954235d 100644
  RUN CGO_ENABLED=1 go build -gcflags "all=-N -l" -o server_debug main.go
 
  # Multi-Stage production build
--FROM golang:1.20.7@sha256:bc5f0b5e43282627279fe5262ae275fecb3d2eae3b33977a7fd200c7a760d6f1 as deploy
+-FROM golang:1.21.1@sha256:c416ceeec1cdf037b80baef1ccb402c230ab83a9134b34c0902c542eb4539c82 as deploy
 +FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 as deploy
 
  # Retrieve the binary from the previous stage
  COPY --from=builder /opt/app-root/src/server /usr/local/bin/fulcio-server
+@@ -41,3 +41,9 @@ RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.0
+
+ # overwrite server and include debugger
+ COPY --from=builder /opt/app-root/src/server_debug /usr/local/bin/fulcio-server
++
+++LABEL description="Fulcio is a free-to-use certificate authority for issuing code signing certificates for an OpenID Connect (OIDC) identity, such as email address."
+++LABEL io.k8s.description="Fulcio is a free-to-use certificate authority for issuing code signing certificates for an OpenID Connect (OIDC) identity, such as email address."
+++LABEL io.k8s.display-name="Fulcio container image for Red Hat Trusted Signer"
+++LABEL io.openshift.tags="fulcio trusted-signer"
+++LABEL summary="Provides the Fulcio CA for keyless signing with Red Hat Trusted Signer."


### PR DESCRIPTION
Modeled on https://github.com/securesign/cosign/pull/14

@lance I'm not sure how `.patch` files should work, is it correct to make a `0002-` as I've done here, or should I overwrite `0001-`?

Also will we need to update the run image to ubi9, as the cosign one does?