### PR TITLE
chore: use fully qualified image specs

### DIFF
--- a/redhat/overlays/Dockerfile
+++ b/redhat/overlays/Dockerfile
@@ -36,7 +36,7 @@ COPY --from=builder /opt/app-root/src/server /usr/local/bin/fulcio-server
 ENTRYPOINT ["/usr/local/bin/fulcio-server", "serve"]
 
 # debug compile options & debugger
-FROM deploy as debug
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 as debug
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.0
 
 # overwrite server and include debugger


### PR DESCRIPTION
RHTAP enterprise contract will fail otherwise.