### PR TITLE
chore: remove unit tests from RHTAP pipeline

### DIFF
--- a/.tekton/fulcio-pull-request.yaml
+++ b/.tekton/fulcio-pull-request.yaml
@@ -375,21 +375,21 @@ spec:
         operator: in
         values:
         - "false"
-    - name: run-unit-tests
-      runAfter:
-      - build-container    
-      taskRef:
-        params:
-        - name: name
-          value: unit-test
-        - name: bundle
-          value: quay.io/securesign/fulcio-unit-test@sha256:d97d2cd9bddd6d8bad215ec0b34175b5c2a5b14673bf0e0b6ad1c823268c9439
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-        - name: source
-          workspace: workspace
+    # - name: run-unit-tests
+    #   runAfter:
+    #   - build-container
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: unit-test
+    #     - name: bundle
+    #       value: quay.io/securesign/fulcio-unit-test@sha256:d97d2cd9bddd6d8bad215ec0b34175b5c2a5b14673bf0e0b6ad1c823268c9439
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   workspaces:
+    #     - name: source
+    #       workspace: workspace
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/fulcio-push.yaml
+++ b/.tekton/fulcio-push.yaml
@@ -372,21 +372,21 @@ spec:
         operator: in
         values:
         - "false"
-    - name: run-unit-tests
-      runAfter:
-      - build-container    
-      taskRef:
-        params:
-        - name: name
-          value: unit-test
-        - name: bundle
-          value: quay.io/securesign/fulcio-unit-test@sha256:d97d2cd9bddd6d8bad215ec0b34175b5c2a5b14673bf0e0b6ad1c823268c9439
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-        - name: source
-          workspace: workspace
+    # - name: run-unit-tests
+    #   runAfter:
+    #   - build-container
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: unit-test
+    #     - name: bundle
+    #       value: quay.io/securesign/fulcio-unit-test@sha256:d97d2cd9bddd6d8bad215ec0b34175b5c2a5b14673bf0e0b6ad1c823268c9439
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   workspaces:
+    #     - name: source
+    #       workspace: workspace
     workspaces:
     - name: workspace
     - name: git-auth


### PR DESCRIPTION
As of today, RHTAP will fail the EC check if there are custom tasks in the pipeline.

See: https://issues.redhat.com/browse/EC-20