### PR TITLE
chore: update github action with correct branch

### DIFF
--- a/.github/workflows/cronjobs.yaml
+++ b/.github/workflows/cronjobs.yaml
@@ -4,13 +4,13 @@ on:
   schedule:
     # Every M-F at 12:00am run this job
     - cron:  "0 0 * * 1-5"
-    
+
 jobs:
   check-image-version:
     uses: securesign/actions/.github/workflows/check-image-version.yaml@main
     strategy:
       matrix:
-        branch: [main, midstream-v1.4.0]
+        branch: [main, midstream-v1.4]
     with:
       branch: ${{ matrix.branch }}
     secrets:


### PR DESCRIPTION
We are now working off of the `redhat-v1.4` branch. Update there.