### PR TITLE
update-image-check-job

### DIFF
--- a/.github/workflows/cronjobs.yaml
+++ b/.github/workflows/cronjobs.yaml
@@ -10,8 +10,9 @@ jobs:
     uses: securesign/actions/.github/workflows/check-image-version.yaml@main
     strategy:
       matrix:
-        branch: [main, redhat-v1.4]
+        branch: [main]
     with:
       branch: ${{ matrix.branch }}
+      images: '["registry.access.redhat.com/ubi9/go-toolset"]'
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
pr to update the check-image-version job to reflect changes in securesign/actions