### PR TITLE
bumping deprecated image check to v0.4 for fulcio

### DIFF
--- a/.tekton/fulcio-pull-request.yaml
+++ b/.tekton/fulcio-pull-request.yaml
@@ -275,6 +275,10 @@ spec:
       params:
       - name: BASE_IMAGES_DIGESTS
         value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      - name: IMAGE_URL
+        value: $(tasks.build-container.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
       runAfter:
       - build-container
       taskRef:

--- a/.tekton/fulcio-push.yaml
+++ b/.tekton/fulcio-push.yaml
@@ -272,6 +272,10 @@ spec:
       params:
       - name: BASE_IMAGES_DIGESTS
         value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      - name: IMAGE_URL
+        value: $(tasks.build-container.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
       runAfter:
       - build-container
       taskRef:


### PR DESCRIPTION
Relates to https://redhat-internal.slack.com/archives/C05M2GGKU7Q/p1715707450761549
/cc @lance