### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for fulcio-server

### DIFF
--- a/Dockerfile.fulcio-server.rh
+++ b/Dockerfile.fulcio-server.rh
@@ -37,7 +37,8 @@ LABEL io.k8s.display-name="Fulcio container image for Red Hat Trusted Signer"
 LABEL io.openshift.tags="fulcio trusted-signer"
 LABEL summary="Provides the Fulcio CA for keyless signing with Red Hat Trusted Signer."
 LABEL com.redhat.component="fulcio"
-LABEL name="fulcio"
+LABEL name="rhtas/fulcio-rhel9"
+LABEL cpe="cpe:/a:redhat:trusted_artifact_signer:1.2::el9"
 
 # Retrieve the binary from the previous stage
 COPY --from=builder /opt/app-root/src/server /usr/local/bin/fulcio-server


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini

## Summary by Sourcery

Set metadata labels in the fulcio-server Dockerfile to enable Clair to retrieve VEX statements for the image

Enhancements:
- Add name label to the fulcio-server Docker image
- Add CPE label to the fulcio-server Docker image to support Clair lookups