### PR TITLE
Add sync-upstream workflow

### DIFF
--- a/.github/workflows/sync-upstream.yaml
+++ b/.github/workflows/sync-upstream.yaml
@@ -1,0 +1,31 @@
+name: Sync Upstream
+on:
+  schedule:
+    - cron: '17 8 * * 1'  # Weekly Monday 8:17 UTC
+  workflow_dispatch:
+    inputs:
+      upstream_ref:
+        description: 'Upstream ref to merge (leave empty for latest release)'
+        required: false
+        default: ''
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ secrets.SYNC_APP_CLIENT_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - uses: securesign/actions/sync-upstream@main
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          upstream_repo: https://github.com/sigstore/fulcio
+          upstream_ref: ${{ inputs.upstream_ref || '' }}
+          take_upstream_patterns: |
+              (^|/)CHANGELOG
+              \.pb\.go$
+          target_branch: main


### PR DESCRIPTION
Adds automated upstream sync with sigstore/fulcio using the shared reusable workflow from securesign/actions. Runs weekly on Monday and supports manual trigger with a specific upstream ref.