### PR TITLE
feat: enable native FIPS support, create FIPS Safe fulcio build

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,6 +53,12 @@ jobs:
         go-version: ${{ env.GOVERSION }}
         check-latest: true
 
+    - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
+      run: |
+        go mod edit -dropgodebug=fips140
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        git update-index --assume-unchanged go.mod
+
     - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
       name: Install protobuf
       with:

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -47,6 +47,12 @@ jobs:
           go-version: '${{ env.GOVERSION }}'
           check-latest: true
 
+      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
+        run: |
+          go mod edit -dropgodebug=fips140
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git update-index --assume-unchanged go.mod
+
       - name: deps
         run: sudo apt-get update && sudo apt-get install -yq libpcsclite-dev
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,7 +36,11 @@ jobs:
 
       - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
 
-      - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
+        run: |
+          go mod edit -dropgodebug=fips140
 
       - name: Start Fulcio services
         run: |
@@ -53,7 +57,8 @@ jobs:
             --out=signing-config.json
 
       - name: Get test OIDC token
-        uses: sigstore-conformance/extremely-dangerous-public-oidc-beacon@main
+        run: |
+          curl -o oidc-token.txt "https://storage.googleapis.com/sigstore-conformance-testing-token/untrusted-testing-token.txt"
 
       - name: Sign and verify with ID token
         run: |
@@ -68,6 +73,6 @@ jobs:
           cosign verify-blob myblob \
             --insecure-ignore-tlog \
             --trusted-root=trusted-root.json \
-            --certificate-identity=https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/.github/workflows/extremely-dangerous-oidc-beacon.yml@refs/heads/main \
-            --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+            --certificate-identity=untrusted-sa@sigstore-conformance.iam.gserviceaccount.com \
+            --certificate-oidc-issuer=https://accounts.google.com \
             --bundle=bundle.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,12 @@ jobs:
           go-version: ${{ env.GOVERSION }}
           check-latest: true
 
+      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
+        run: |
+          go mod edit -dropgodebug=fips140
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git update-index --assume-unchanged go.mod
+
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         name: Install protobuf
         with:

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -33,9 +33,9 @@ jobs:
     steps:
       - name: Check Signature
         run: |
-          cosign verify ghcr.io/gythialy/golang-cross:v1.25.5-0@sha256:3a7d463d9e3438513b6bd597c79f7d5db756023e04718259cc25aabd5d00fc17 \
+          cosign verify ghcr.io/gythialy/golang-cross:v1.26.3-0@sha256:9f7a53d7205e2f1f2742d624ff0b6e1531e8c22863dfb24ca966be5efbdee48b \
           --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-          --certificate-identity "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/v1.25.5-0"
+          --certificate-identity "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/v1.26.3-0"
         env:
           TUF_ROOT: /tmp
 
@@ -44,12 +44,18 @@ jobs:
     needs:
       - check-signature
     container:
-      image: ghcr.io/gythialy/golang-cross:v1.25.5-0@sha256:3a7d463d9e3438513b6bd597c79f7d5db756023e04718259cc25aabd5d00fc17
+      image: ghcr.io/gythialy/golang-cross:v1.26.3-0@sha256:9f7a53d7205e2f1f2742d624ff0b6e1531e8c22863dfb24ca966be5efbdee48b
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
+
+      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
+        run: |
+          go mod edit -dropgodebug=fips140
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git update-index --assume-unchanged go.mod
 
       # Error: fatal: detected dubious ownership in repository at '/__w/fulcio/fulcio'
       #      To add an exception for this directory, call:

--- a/.github/workflows/verify-k8s.yml
+++ b/.github/workflows/verify-k8s.yml
@@ -37,6 +37,12 @@ jobs:
           go-version: '${{ env.GOVERSION }}'
           check-latest: true
 
+      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
+        run: |
+          go mod edit -dropgodebug=fips140
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git update-index --assume-unchanged go.mod
+
       - name: Install kubeconform
         run: go install github.com/yannh/kubeconform/cmd/kubeconform@e65429b1e5990dd019ebb7b5642dcd22a3e9cd13 # v0.7.0
 
@@ -80,6 +86,12 @@ jobs:
         with:
           go-version: '${{ env.GOVERSION }}'
           check-latest: true
+
+      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
+        run: |
+          go mod edit -dropgodebug=fips140
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git update-index --assume-unchanged go.mod
 
       - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -41,6 +41,12 @@ jobs:
           go-version: '${{ env.GOVERSION }}'
           check-latest: true
 
+      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
+        run: |
+          go mod edit -dropgodebug=fips140
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git update-index --assume-unchanged go.mod
+
       - name: Install addlicense
         run: go install github.com/google/addlicense@v1.0.0
 
@@ -69,10 +75,16 @@ jobs:
           go-version: '${{ env.GOVERSION }}'
           check-latest: true
 
+      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
+        run: |
+          go mod edit -dropgodebug=fips140
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git update-index --assume-unchanged go.mod
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.6
+          version: v2.12
 
   oidc-config:
     name: oidc-config
@@ -89,6 +101,12 @@ jobs:
         with:
           go-version: '${{ env.GOVERSION }}'
           check-latest: true
+
+      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
+        run: |
+          go mod edit -dropgodebug=fips140
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git update-index --assume-unchanged go.mod
 
       - name: check-config
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.25.7@sha256:5a79b94c34c299ac0361fbb7c7fca6dc552e166b42341050323fa3ab137d7be9 AS builder
+FROM golang:1.26.3@sha256:2d6c80227255c3112a4d08e67ba98e58efd3846daf15d9d7d4c389565d881b1a AS builder
 ENV APP_ROOT=/opt/app-root
 ENV GOPATH=$APP_ROOT
 
@@ -28,7 +28,7 @@ RUN go build -o server main.go
 RUN CGO_ENABLED=1 go build -gcflags "all=-N -l" -o server_debug main.go
 
 # Multi-Stage production build
-FROM golang:1.25.7@sha256:5a79b94c34c299ac0361fbb7c7fca6dc552e166b42341050323fa3ab137d7be9 AS deploy
+FROM golang:1.26.3@sha256:2d6c80227255c3112a4d08e67ba98e58efd3846daf15d9d7d4c389565d881b1a AS deploy
 
 # Retrieve the binary from the previous stage
 COPY --from=builder /opt/app-root/src/server /usr/local/bin/fulcio-server

--- a/Dockerfile.fulcio-server.rh
+++ b/Dockerfile.fulcio-server.rh
@@ -13,12 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.redhat.io/ubi9/go-toolset:9.7-1774618347@sha256:a05a1c82b3ce23864a831084ff21a907128f4707ca3f455ba99717c0c2c4d6c1 AS builder
+FROM registry.redhat.io/ubi9/go-toolset:9.8@sha256:355b23fe885cf565c9313a7e98db742df0aec21456244e808942c56489594251 AS builder
 
-ENV GOEXPERIMENT=strictfipsruntime
 ENV CGO_ENABLED=1
 ENV APP_ROOT=/opt/app-root
 ENV GOPATH=$APP_ROOT
+ENV GOFIPS140=v1.0.0
 
 WORKDIR $APP_ROOT/src/
 ADD go.mod go.sum $APP_ROOT/src/
@@ -26,7 +26,7 @@ ADD go.mod go.sum $APP_ROOT/src/
 ADD ./ $APP_ROOT/src/
 
 RUN go mod download && \
-    go build -mod=readonly -o server main.go
+    go build -mod=readonly -tags=no_openssl -o server main.go
 
 # Multi-Stage production build
 FROM registry.access.redhat.com/ubi9-minimal@sha256:383329bf9c4f968e87e85d30ba3a5cb988a3bbde28b8e4932dcd3a025fd9c98c as deploy

--- a/Dockerfile.tesseract
+++ b/Dockerfile.tesseract
@@ -16,7 +16,7 @@
 
 FROM ghcr.io/transparency-dev/tesseract/posix:v0.1.1@sha256:8269c32a1b1deb159ba75016421314cb5e68304c2813d444aca3efdf0e9d5027 AS server
 
-FROM golang:1.25.7@sha256:5a79b94c34c299ac0361fbb7c7fca6dc552e166b42341050323fa3ab137d7be9 AS deploy
+FROM golang:1.26.3@sha256:2d6c80227255c3112a4d08e67ba98e58efd3846daf15d9d7d4c389565d881b1a AS deploy
 
 COPY --from=server /ko-app/posix /usr/local/bin/tesseract
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/sigstore/fulcio
 
-go 1.25.7
+go 1.26.3
+
+godebug fips140=auto
 
 require (
 	chainguard.dev/go-grpc-kit v0.17.17

--- a/pkg/ca/common.go
+++ b/pkg/ca/common.go
@@ -18,7 +18,10 @@ package ca
 import (
 	"context"
 	"crypto"
+	"crypto/fips140"
+	"crypto/sha256"
 	"crypto/x509"
+	"encoding/asn1"
 	"errors"
 	"time"
 
@@ -33,10 +36,18 @@ func MakeX509(ctx context.Context, principal identity.Principal, publicKey crypt
 		return nil, err
 	}
 
-	skid, err := cryptoutils.SKID(publicKey)
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	var skid []byte
+	if fips140.Enabled() {
+		skid, err = computeSKID(publicKey)
+	} else {
+		skid, err = cryptoutils.SKID(publicKey)
+	}
 	if err != nil {
 		return nil, err
 	}
+	// ========================================
 
 	cert := &x509.Certificate{
 		SerialNumber: serialNumber,
@@ -106,3 +117,26 @@ func VerifyCertChain(certs []*x509.Certificate, signer crypto.Signer) error {
 
 	return goodkey.ValidatePubKey(signer.Public())
 }
+
+// RHTAS FIPS - DO NOT REMOVE
+// ========================================
+type subjectPublicKeyInfo struct {
+	Algorithm        asn1.RawValue
+	SubjectPublicKey asn1.BitString
+}
+
+// computeSKID computes a Subject Key Identifier using SHA-256 (truncated to 20 bytes).
+func computeSKID(pub crypto.PublicKey) ([]byte, error) {
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return nil, err
+	}
+	var spki subjectPublicKeyInfo
+	if _, err := asn1.Unmarshal(der, &spki); err != nil {
+		return nil, err
+	}
+	hash := sha256.Sum256(spki.SubjectPublicKey.Bytes)
+	return hash[:20], nil
+}
+
+// ========================================

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,6 +17,7 @@ package config
 
 import (
 	"context"
+	"crypto/fips140"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -237,7 +238,17 @@ func (fc *FulcioConfig) GetVerifier(issuerURL string, opts ...InsecureOIDCConfig
 	ctx, cancel := context.WithTimeout(context.Background(), defaultOIDCDiscoveryTimeout)
 	defer cancel()
 
-	provider, err := oidc.NewProvider(oidc.ClientContext(ctx, client), issuerURL)
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	// go-jose unconditionally computes SHA-1 x5t thumbprints during JWKS parsing,
+	// which panics in FIPS 140-only mode. SHA-1 is used here only as a non-cryptographic
+	// key identifier, not for security. Remove once go-jose merges FIPS support:
+	// https://github.com/go-jose/go-jose/pull/219
+	var provider *oidc.Provider
+	fips140.WithoutEnforcement(func() {
+		provider, err = oidc.NewProvider(oidc.ClientContext(ctx, client), issuerURL)
+	})
+	// ========================================
 	if err != nil {
 		log.Logger.Errorf("Failed to create provider for issuer URL %q: %v", issuerURL, err)
 		return nil, false
@@ -386,7 +397,17 @@ func (fc *FulcioConfig) insertVerifier(iss OIDCIssuer) error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultOIDCDiscoveryTimeout)
 	defer cancel()
-	provider, err := oidc.NewProvider(oidc.ClientContext(ctx, client), iss.IssuerURL)
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	// go-jose unconditionally computes SHA-1 x5t thumbprints during JWKS parsing,
+	// which panics in FIPS 140-only mode. SHA-1 is used here only as a non-cryptographic
+	// key identifier, not for security. Remove once go-jose merges FIPS support:
+	// https://github.com/go-jose/go-jose/pull/219
+	var provider *oidc.Provider
+	fips140.WithoutEnforcement(func() {
+		provider, err = oidc.NewProvider(oidc.ClientContext(ctx, client), iss.IssuerURL)
+	})
+	// ========================================
 	if err != nil {
 		return err
 	}

--- a/pkg/identity/authorize.go
+++ b/pkg/identity/authorize.go
@@ -16,6 +16,7 @@ package identity
 
 import (
 	"context"
+	"crypto/fips140"
 	"fmt"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -35,5 +36,17 @@ func actualAuthorize(ctx context.Context, token string, opts ...config.InsecureO
 	if !ok {
 		return nil, fmt.Errorf("unsupported issuer: %s", issuer)
 	}
-	return verifier.Verify(ctx, token)
+	var idToken *oidc.IDToken
+	var verifyErr error
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	// go-jose unconditionally computes SHA-1 x5t thumbprints during JWKS parsing,
+	// which panics in FIPS 140-only mode. SHA-1 is used here only as a non-cryptographic
+	// key identifier, not for security. Remove once go-jose merges FIPS support:
+	// https://github.com/go-jose/go-jose/pull/219
+	fips140.WithoutEnforcement(func() {
+		idToken, verifyErr = verifier.Verify(ctx, token)
+	})
+	// ========================================
+	return idToken, verifyErr
 }

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -18,6 +18,7 @@ package server
 import (
 	"context"
 	"crypto"
+	"crypto/fips140"
 	"crypto/x509"
 	"encoding/json"
 	"errors"
@@ -332,6 +333,12 @@ func getHashFuncForSignatureAlgorithm(signatureAlgorithm x509.SignatureAlgorithm
 	case x509.SHA512WithRSA:
 		return crypto.SHA512, nil
 	case x509.PureEd25519:
+		// RHTAS FIPS - DO NOT REMOVE
+		// ========================================
+		if fips140.Enabled() {
+			return crypto.Hash(0), fmt.Errorf("Ed25519 is not supported in FIPS mode")
+		}
+		// ========================================
 		return crypto.Hash(0), nil
 	}
 	return crypto.Hash(0), fmt.Errorf("unrecognized signature algorithm: %s", signatureAlgorithm)


### PR DESCRIPTION
## Summary
- Add FIPS 140 runtime checks to ensure fulcio-server operates with only FIPS-approved cryptographic algorithms when running on a FIPS-enabled system
- Wrap go-jose OIDC provider calls with `fips140.WithoutEnforcement()` to prevent SHA-1 x5t thumbprint panics (non-security-relevant use)
- Replace SHA-1 based Subject Key Identifier (SKID) computation with SHA-256 (truncated to 20 bytes) when FIPS is enabled
- Reject Ed25519 keys at the CA key loading and CSR signature verification layers in FIPS mode
- All FIPS-specific code blocks are marked with `RHTAS FIPS - DO NOT REMOVE` banners to prevent accidental removal during upstream syncs

## Changes
- **pkg/ca/common.go** — FIPS-conditional SKID computation (SHA-256 vs SHA-1), added `computeSKID()` helper
- **pkg/config/config.go** — Wrapped two `oidc.NewProvider` calls with `fips140.WithoutEnforcement()` for go-jose SHA-1 x5t compatibility
- **pkg/identity/authorize.go** — Wrapped `verifier.Verify()` with `fips140.WithoutEnforcement()` for go-jose SHA-1 x5t compatibility
- **pkg/ca/fileca/load.go** — Reject Ed25519 private keys when loading CA signing keys in FIPS mode
- **pkg/server/grpc_server.go** — Reject Ed25519 CSR signature algorithm in FIPS mode
