### PR TITLE
fix: guard cryptoutils.EqualKeys SHA-1 panic under FIPS 140-only mode

### DIFF
--- a/pkg/ca/common.go
+++ b/pkg/ca/common.go
@@ -111,9 +111,19 @@ func VerifyCertChain(certs []*x509.Certificate, signer crypto.Signer) error {
 		}
 	}
 
-	if err := cryptoutils.EqualKeys(certs[0].PublicKey, signer.Public()); err != nil {
-		return err
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	// cryptoutils.EqualKeys calls SKID (SHA-1) in its error-message path,
+	// which panics under fips140=only. SHA-1 is used here only as a
+	// diagnostic key fingerprint, not for security.
+	var equalKeysErr error
+	fips140.WithoutEnforcement(func() {
+		equalKeysErr = cryptoutils.EqualKeys(certs[0].PublicKey, signer.Public())
+	})
+	if equalKeysErr != nil {
+		return equalKeysErr
 	}
+	// ========================================
 
 	return goodkey.ValidatePubKey(signer.Public())
 }

--- a/pkg/certmaker/cert_loader.go
+++ b/pkg/certmaker/cert_loader.go
@@ -16,6 +16,7 @@
 package certmaker
 
 import (
+	"crypto/fips140"
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
@@ -93,10 +94,19 @@ func ValidateCertificateKeyMatch(cert *x509.Certificate, sv signature.SignerVeri
 	// get public key from cert
 	certPubKey := cert.PublicKey
 
-	// compare public keys using sigstore cryptoutils
-	if err := cryptoutils.EqualKeys(certPubKey, kmsPubKey); err != nil {
-		return fmt.Errorf("%w: %v", ErrKeyMismatch, err)
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	// cryptoutils.EqualKeys calls SKID (SHA-1) in its error-message path,
+	// which panics under fips140=only. SHA-1 is used here only as a
+	// diagnostic key fingerprint, not for security.
+	var equalKeysErr error
+	fips140.WithoutEnforcement(func() {
+		equalKeysErr = cryptoutils.EqualKeys(certPubKey, kmsPubKey)
+	})
+	if equalKeysErr != nil {
+		return fmt.Errorf("%w: %v", ErrKeyMismatch, equalKeysErr)
 	}
+	// ========================================
 
 	return nil
 }


### PR DESCRIPTION
## Summary
- Wrap `cryptoutils.EqualKeys` calls with `fips140.WithoutEnforcement()` in
  `pkg/ca/common.go` and `pkg/certmaker/cert_loader.go`