### PR TITLE
fix: restore CI on release-1.3 (ko-publish, golangci-lint, e2e OIDC token)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -53,7 +53,8 @@ jobs:
             --out=signing-config.json
 
       - name: Get test OIDC token
-        uses: sigstore-conformance/extremely-dangerous-public-oidc-beacon@main
+        run: |
+          curl -sSfL https://storage.googleapis.com/sigstore-conformance-testing-token/untrusted-testing-token.txt -o oidc-token.txt
 
       - name: Sign and verify with ID token
         run: |
@@ -68,6 +69,6 @@ jobs:
           cosign verify-blob myblob \
             --insecure-ignore-tlog \
             --trusted-root=trusted-root.json \
-            --certificate-identity=https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/.github/workflows/extremely-dangerous-oidc-beacon.yml@refs/heads/main \
-            --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+            --certificate-identity=untrusted-sa@sigstore-conformance.iam.gserviceaccount.com \
+            --certificate-oidc-issuer=https://accounts.google.com \
             --bundle=bundle.json

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -72,7 +72,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.6
+          version: latest
 
   oidc-config:
     name: oidc-config

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ ko-apply-ci:
 
 .PHONY: ko-publish
 ko-publish:
-	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) ko publish .
+	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) ko publish --insecure-registry .
 
 .PHONY: sign-keyless-ci
 sign-keyless-ci: ko


### PR DESCRIPTION
## Summary

Three pre-existing CI failures on `release-1.3`, all backported from fixes already applied on `release-1.4`.

---

## Fix 1: Add `--insecure-registry` to `ko-publish` (Makefile)

**Failing job:** `verify-k8s-deployment`

The KinD cluster CI uses an HTTP-only local registry at `registry.local:5000`. The `ko-publish` Makefile target was missing `--insecure-registry`, causing it to attempt HTTPS and fail:

```
Get "https://registry.local:5000/v2/": http: server gave HTTP response to HTTPS client
```

Commit `7a57aa27` ("Adding insecure registry to ko for ci tests") added the flag to `ko-apply-ci` but missed `ko-publish`. This adds it to match.

---

## Fix 2: Upgrade golangci-lint to `latest` (.github/workflows/verify.yml)

**Failing job:** `golangci-lint` (exit code 2, panic)

`version: v2.6` was pinned in the workflow, downloading golangci-lint v2.6.2 which was built with Go 1.25. A transitive dependency now declares `go 1.26` in its `go.mod`, causing the embedded `go/types` to panic:

```
panic: file requires newer Go version go1.26 (application built with go1.25)
```

Cherry-picked from `a9729b3` on `release-1.4` ("update golangci-lint to latest").

---

## Fix 3: Replace deprecated OIDC beacon action in e2e workflow (.github/workflows/e2e.yml)

**Failing job:** `Verify docker compose functionality with cosign`

The `sigstore-conformance/extremely-dangerous-public-oidc-beacon@main` action is deprecated and broken. Updated to fetch the test token directly via `curl` and updated `--certificate-identity` and `--certificate-oidc-issuer` in `cosign verify-blob` to match the new GCP service account token.

Ported from `release-1.4` where the same fix was already applied.

Co-Authored-by: Claude