### PR TITLE
FIPS: allow Ed25519, move godebug to RH Dockerfile, remove CI workarounds

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,12 +53,6 @@ jobs:
         go-version: ${{ env.GOVERSION }}
         check-latest: true
 
-    - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-      run: |
-        go mod edit -dropgodebug=fips140
-        git config --global --add safe.directory "$GITHUB_WORKSPACE"
-        git update-index --assume-unchanged go.mod
-
     - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
       name: Install protobuf
       with:

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -47,12 +47,6 @@ jobs:
           go-version: '${{ env.GOVERSION }}'
           check-latest: true
 
-      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-        run: |
-          go mod edit -dropgodebug=fips140
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git update-index --assume-unchanged go.mod
-
       - name: deps
         run: sudo apt-get update && sudo apt-get install -yq libpcsclite-dev
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,10 +38,6 @@ jobs:
 
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
-      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-        run: |
-          go mod edit -dropgodebug=fips140
-
       - name: Start Fulcio services
         run: |
           docker compose up --build --wait -d

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,12 +41,6 @@ jobs:
           go-version: ${{ env.GOVERSION }}
           check-latest: true
 
-      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-        run: |
-          go mod edit -dropgodebug=fips140
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git update-index --assume-unchanged go.mod
-
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         name: Install protobuf
         with:

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -51,12 +51,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-        run: |
-          go mod edit -dropgodebug=fips140
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git update-index --assume-unchanged go.mod
-
       # Error: fatal: detected dubious ownership in repository at '/__w/fulcio/fulcio'
       #      To add an exception for this directory, call:
       #          git config --system --add safe.directory /__w/fulcio/fulcio

--- a/.github/workflows/verify-k8s.yml
+++ b/.github/workflows/verify-k8s.yml
@@ -37,12 +37,6 @@ jobs:
           go-version: '${{ env.GOVERSION }}'
           check-latest: true
 
-      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-        run: |
-          go mod edit -dropgodebug=fips140
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git update-index --assume-unchanged go.mod
-
       - name: Install kubeconform
         run: go install github.com/yannh/kubeconform/cmd/kubeconform@e65429b1e5990dd019ebb7b5642dcd22a3e9cd13 # v0.7.0
 
@@ -86,12 +80,6 @@ jobs:
         with:
           go-version: '${{ env.GOVERSION }}'
           check-latest: true
-
-      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-        run: |
-          go mod edit -dropgodebug=fips140
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git update-index --assume-unchanged go.mod
 
       - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
 

--- a/.github/workflows/verify-k8s.yml
+++ b/.github/workflows/verify-k8s.yml
@@ -65,6 +65,7 @@ jobs:
       REGISTRY_NAME: registry.local
       REGISTRY_PORT: 5000
       KO_PREFIX: registry.local:5000/fulcio
+      INSECURE_REGISTRY: true
       GIT_HASH: ${{ github.sha }}
       GIT_VERSION: test
 
@@ -198,7 +199,7 @@ jobs:
 
       - name: Validate prometheus metrics exported and look correct
         run: |
-          cat <<EOF | ko apply -f -
+          cat <<EOF | ko apply --insecure-registry -f -
           apiVersion: batch/v1
           kind: Job
           metadata:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -41,12 +41,6 @@ jobs:
           go-version: '${{ env.GOVERSION }}'
           check-latest: true
 
-      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-        run: |
-          go mod edit -dropgodebug=fips140
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git update-index --assume-unchanged go.mod
-
       - name: Install addlicense
         run: go install github.com/google/addlicense@v1.0.0
 
@@ -75,12 +69,6 @@ jobs:
           go-version: '${{ env.GOVERSION }}'
           check-latest: true
 
-      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-        run: |
-          go mod edit -dropgodebug=fips140
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git update-index --assume-unchanged go.mod
-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
@@ -101,12 +89,6 @@ jobs:
         with:
           go-version: '${{ env.GOVERSION }}'
           check-latest: true
-
-      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-        run: |
-          go mod edit -dropgodebug=fips140
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git update-index --assume-unchanged go.mod
 
       - name: check-config
         run: |

--- a/Dockerfile.fulcio-server.rh
+++ b/Dockerfile.fulcio-server.rh
@@ -25,7 +25,9 @@ ADD go.mod go.sum $APP_ROOT/src/
 # Add source code
 ADD ./ $APP_ROOT/src/
 
-RUN go mod download && \
+USER root
+RUN go mod edit -godebug=fips140=auto && \
+    go mod download && \
     go build -mod=readonly -tags=no_openssl -o server main.go
 
 # Multi-Stage production build

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,10 @@ LDFLAGS=-X $(FULCIO_VERSION_PKG).gitVersion=$(GIT_VERSION)
 KO_PREFIX ?= gcr.io/projectsigstore
 export KO_DOCKER_REPO=$(KO_PREFIX)
 
+ifdef INSECURE_REGISTRY
+KO_FLAGS += --insecure-registry
+endif
+
 GHCR_PREFIX ?= ghcr.io/sigstore
 
 FULCIO_YAML ?= fulcio-$(GIT_TAG).yaml
@@ -102,28 +106,28 @@ debug: ## Start docker compose in debug mode
 ko:
 	# fulcio
 	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
-	KO_DOCKER_REPO=$(KO_PREFIX)/fulcio ko resolve --bare \
+	KO_DOCKER_REPO=$(KO_PREFIX)/fulcio ko resolve --bare $(KO_FLAGS) \
 		--platform=linux/amd64 --tags $(GIT_VERSION) --tags $(GIT_HASH) \
 		--image-refs fulcioImagerefs --filename config/ > $(FULCIO_YAML)
 
 .PHONY: ko-local
 ko-local:
 	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
-	ko publish --base-import-paths \
+	ko publish --base-import-paths $(KO_FLAGS) \
 		--platform=linux/amd64 --tags $(GIT_VERSION) --tags $(GIT_HASH) --local \
 		github.com/sigstore/fulcio
 
 .PHONY: ko-apply
 ko-apply:
-	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) ko apply -Bf config/
+	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) ko apply $(KO_FLAGS) -Bf config/
 
 .PHONY: ko-apply-ci
 ko-apply-ci: ko-apply
-	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) ko apply -Bf config/test
+	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) ko apply $(KO_FLAGS) -Bf config/test
 
 .PHONY: ko-publish
 ko-publish:
-	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) ko publish .
+	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) ko publish $(KO_FLAGS) .
 
 .PHONY: sign-keyless-ci
 sign-keyless-ci: ko

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/sigstore/fulcio
 
 go 1.26.3
 
-godebug fips140=auto
-
 require (
 	chainguard.dev/go-grpc-kit v0.17.17
 	chainguard.dev/sdk v0.1.52

--- a/pkg/ca/fileca/load.go
+++ b/pkg/ca/fileca/load.go
@@ -111,12 +111,6 @@ func loadUnencryptedKey(keyPath string) (crypto.Signer, error) {
 		case *rsa.PrivateKey:
 			key = k
 		case ed25519.PrivateKey:
-			// RHTAS FIPS - DO NOT REMOVE
-			// ========================================
-			if fips140.Enabled() {
-				return nil, fmt.Errorf("fileca: Ed25519 keys are not supported in FIPS mode")
-			}
-			// ========================================
 			key = k
 		default:
 			return nil, errors.New("fileca: unsupported key type in PKCS#8 container")

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -18,7 +18,7 @@ package server
 import (
 	"context"
 	"crypto"
-	"crypto/fips140"
+
 	"crypto/x509"
 	"encoding/json"
 	"errors"
@@ -333,12 +333,6 @@ func getHashFuncForSignatureAlgorithm(signatureAlgorithm x509.SignatureAlgorithm
 	case x509.SHA512WithRSA:
 		return crypto.SHA512, nil
 	case x509.PureEd25519:
-		// RHTAS FIPS - DO NOT REMOVE
-		// ========================================
-		if fips140.Enabled() {
-			return crypto.Hash(0), fmt.Errorf("Ed25519 is not supported in FIPS mode")
-		}
-		// ========================================
 		return crypto.Hash(0), nil
 	}
 	return crypto.Hash(0), fmt.Errorf("unrecognized signature algorithm: %s", signatureAlgorithm)


### PR DESCRIPTION
## Summary

- **Allow Ed25519 in FIPS mode**: Removed Ed25519 FIPS guards from `fileca/load.go` and `grpc_server.go`. Ed25519 is approved under FIPS 186-5 and is included in Go's CMVP-validated FIPS 140-3 module (Certificate #5247).
- **Relocate FIPS godebug**: Moved `godebug fips140=auto` from `go.mod` into `Dockerfile.fulcio-server.rh` via `go mod edit -godebug=fips140=auto`. FIPS posture is now injected only at Red Hat build time, keeping `go.mod` clean for upstream.
- **Remove CI workarounds**: Deleted 10 "Remove RHTAS FIPS godebug" step blocks across 7 GitHub Actions workflows that were stripping the directive before upstream builds/tests.
